### PR TITLE
Avoid Halving Mouse Coordinates If FULLSCREEN Macro is Enabled

### DIFF
--- a/renderer.h
+++ b/renderer.h
@@ -17,7 +17,7 @@ public:
 	void MouseDown( int button ) { button = 0; /* implement if you want to detect mouse button presses */ }
 	void MouseMove( int x, int y )
 	{
-	#ifdef DOUBLESIZE
+	#if defined(DOUBLESIZE) && !defined(FULLSCREEN)
 		mousePos.x = x / 2, mousePos.y = y / 2;
 	#else
 		mousePos.x = x, mousePos.y = y;


### PR DESCRIPTION
This PR fixes the mouse coordinates when both the FULLSCREEN and DOUBLESIZE macros are enabled.


#### Before this change:

https://github.com/jbikker/voxpopuli/assets/36315399/201f6e7e-5ec8-4422-be70-f13b71b2fa3a


#### After this change:

https://github.com/jbikker/voxpopuli/assets/36315399/905540f0-872e-4ec9-9102-5b2eb6eece98
